### PR TITLE
fixed bug when svm_type = 2 (one-class SVM). 

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,3 +13,9 @@ gc()
 (class, decvalues) = svmpredict(model, sparse(instances[:, 2:2:end]))
 correct = Bool[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1]
 @assert (class .== labels[2:2:end]) == correct
+
+# one-class svm
+z = (labels .== labels[1])
+model = svmtrain(labels[z], instances[:, z]; svm_type=int32(2), verbose=true)
+(class, decvalues) = svmpredict(model, instances[:, z])
+@assert mean(class .== labels[1]) > 0.1  # more than 10% within the class


### PR DESCRIPTION
In this case, predicted label = NaN if not within the class.
