### PR TITLE
fix missing array() function in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ iris = dataset("datasets", "iris")
 labels = iris[:Species]
 
 # First dimension of input data is features; second is instances
-instances = array(iris[:, 1:4])'
+instances = convert(Array, iris[:, 1:4])'
 
 # Train SVM on half of the data using default parameters. See the svmtrain
 # function in LIBSVM.jl for optional parameter settings.


### PR DESCRIPTION
The readme example currently fails with a `MethodError` on Julia v0.5. This gets the example working again. 

I have not tested this on v0.4, but it looks like v0.4 support is on its way out anyway. 