### PR TITLE
Apply to ScikitLearn.jl Julia models

### DIFF
--- a/src/ScikitLearnAPI.jl
+++ b/src/ScikitLearnAPI.jl
@@ -4,17 +4,17 @@ import ScikitLearnBase: predict, predict_proba,
                         set_params!
 
 function predict(model::Union{AbstractSVC, AbstractSVR} , X::AbstractArray)
-    (p,d) = svmpredict(model.fit, X)
+    (p,d) = svmpredict(model.fit, X')
     return p
 end
 
 function predict(model::LinearSVC, X::AbstractArray)
-    (p,d) = LIBLINEAR.linear_predict(model.fit, X)
+    (p,d) = LIBLINEAR.linear_predict(model.fit, X')
     return p
 end
 
 function transform(model::OneClassSVM, X::AbstractArray)
-    (p,d) = svmpredict(model.fit, X)
+    (p,d) = svmpredict(model.fit, X')
     return p
 end
 
@@ -67,7 +67,7 @@ LinearSVC(;solver = Linearsolver.L2R_L2LOSS_SVC_DUAL,
 
 function fit!(model::Union{AbstractSVC,AbstractSVR}, X::AbstractMatrix, y::Vector=[])
     #Build arguments for calling svmtrain
-    model.gamma == :auto && (model.gamma = 1.0/size(X, 1))
+    model.gamma == :auto && (model.gamma = 1.0/size(X', 1))
     kwargs = Tuple{Symbol, Any}[]
     push!(kwargs, (:svmtype, typeof(model)))
     for fn in fieldnames(model)
@@ -76,7 +76,7 @@ function fit!(model::Union{AbstractSVC,AbstractSVR}, X::AbstractMatrix, y::Vecto
         end
     end
 
-    model.fit = svmtrain(X, y; kwargs...)
+    model.fit = svmtrain(X', y; kwargs...)
     return(model)
 end
 
@@ -98,7 +98,7 @@ function get_params(model::Union{AbstractSVC,AbstractSVR, LinearSVC})
 end
 
 function fit!(model::LinearSVC, X::AbstractMatrix, y::Vector)
-    model.fit = LIBLINEAR.linear_train(y, X, solver_type = Int32(model.solver),
+    model.fit = LIBLINEAR.linear_train(y, X', solver_type = Int32(model.solver),
     weights = model.weights, C = model.cost, bias = model.bias,
     p = model.p, eps = model.tolerance, verbose = model.verbose)
     return(model)

--- a/src/ScikitLearnAPI.jl
+++ b/src/ScikitLearnAPI.jl
@@ -25,6 +25,7 @@ SVC(;kernel::Kernel.KERNEL = Kernel.RadialBasis, gamma::Union{Float64,Symbol} = 
     verbose::Bool = false) = SVC(kernel, gamma,
     weights, cost, degree, coef0, tolerance, shrinking,
     probability, verbose, nothing)
+@declare_hyperparameters(SVC, [:kernel, :gamma, :weights, :cost, :degree, :coef0, :tolerance])
 
 NuSVC(;kernel::Kernel.KERNEL = Kernel.RadialBasis, gamma::Union{Float64,Symbol} = :auto,
         weights = nothing, nu::Float64 = 0.5, cost::Float64 = 1.0,
@@ -32,6 +33,7 @@ NuSVC(;kernel::Kernel.KERNEL = Kernel.RadialBasis, gamma::Union{Float64,Symbol} 
         tolerance::Float64 = .001, shrinking::Bool = true,
         verbose::Bool = false,) = NuSVC(kernel, gamma, weights, nu, cost,
             degree, coef0, tolerance, shrinking, verbose, nothing)
+@declare_hyperparameters(NuSVC, [:kernel, :gamma, :weights, :nu, :cost, :degree, :coef0, :tolerance])
 
 OneClassSVM(;kernel::Kernel.KERNEL = Kernel.RadialBasis, gamma::Union{Float64,Symbol} = :auto,
         nu::Float64 = 0.1, cost::Float64 = 1.0, degree::Int32 = Int32(3),
@@ -39,12 +41,14 @@ OneClassSVM(;kernel::Kernel.KERNEL = Kernel.RadialBasis, gamma::Union{Float64,Sy
         shrinking::Bool = true,
         verbose::Bool = false,) = OneClassSVM(kernel, gamma, nu, cost,
         degree, coef0, tolerance, shrinking, verbose, nothing)
+@declare_hyperparameters(OneClassSVM, [:kernel, :gamma, :nu, :cost, :degree, :coef0, :tolerance])
 
 NuSVR(;kernel::Kernel.KERNEL = Kernel.RadialBasis, gamma::Union{Float64,Symbol} = :auto,
         nu::Float64 = 0.5, cost::Float64 = 1.0, degree::Int32 = Int32(3), coef0::Float64 = 0.,
         tolerance::Float64 = .001, shrinking::Bool = true,
         verbose::Bool = false,) = NuSVR(kernel, gamma, nu, cost,
                     degree, coef0, tolerance, shrinking, verbose, nothing)
+@declare_hyperparameters(NuSVR, [:kernel, :gamma, :nu, :cost, :degree, :coef0, :tolerance])
 
 EpsilonSVR(;kernel::Kernel.KERNEL = Kernel.RadialBasis, gamma::Union{Float64,Symbol} = :auto,
         epsilon::Float64 = 0.1, cost::Float64 = 1.0,
@@ -52,12 +56,14 @@ EpsilonSVR(;kernel::Kernel.KERNEL = Kernel.RadialBasis, gamma::Union{Float64,Sym
         tolerance::Float64 = .001, shrinking::Bool = true,
         verbose::Bool = false,) = EpsilonSVR(kernel, gamma, epsilon, cost,
                         degree, coef0, tolerance, shrinking, verbose, nothing)
+@declare_hyperparameters(EpsilonSVR, [:kernel, :gamma, :epsilon, :cost, :degree, :coef0, :tolerance])
 
 LinearSVC(;solver = Linearsolver.L2R_L2LOSS_SVC_DUAL,
           weights::Union{Dict, Void} = nothing, tolerance::Float64=Inf,
           cost::Float64 = 1.0, p::Float64 = 0.1, bias::Float64 = -1.0,
           verbose::Bool = false) = LinearSVC(solver, weights, tolerance,
           cost, p, bias, verbose, nothing)
+@declare_hyperparameters(LinearSVC, [:solver, :weights, :tolerance, :cost, :p, :bias])
 
 function fit!(model::Union{AbstractSVC,AbstractSVR}, X::AbstractMatrix, y::Vector=[])
     #Build arguments for calling svmtrain

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ y = Array(whiteside[:Temp])
 
 m = svmtrain(X, y, svmtype = EpsilonSVR, cost = 10., gamma = 1.)
 yeps, d = svmpredict(m, X)
-@test_approx_eq(sum(yeps - y), 7.455509045783046)
+@test sum(yeps - y) ≈ 7.455509045783046
 skm = fit!(EpsilonSVR(cost = 10., gamma = 1.), X', y)
 ysk = predict(skm, X')
 @test yeps == ysk
@@ -35,14 +35,14 @@ ysk = predict(skm, X')
 nu1 = svmtrain(X, y, svmtype = NuSVR, cost = 10.,
                 nu = .7, gamma = 2., tolerance = .001)
 ynu1, d = svmpredict(nu1, X)
-@test_approx_eq(sum(ynu1 - y), 14.184665717092)
+@test sum(ynu1 - y) ≈ 14.184665717092
 sknu1 = fit!(NuSVR(cost = 10., nu=.7, gamma = 2.), X', y)
 ysknu1 = predict(sknu1, X')
 @test ysknu1 == ynu1
 
 nu2 = svmtrain(X, y, svmtype = NuSVR, cost = 10., nu = .9)
 ynu2, d =svmpredict(nu2, X)
-@test_approx_eq(sum(ynu2 - y), 6.686819661799177)
+@test sum(ynu2 - y) ≈ 6.686819661799177
 sknu2 = fit!(NuSVR(cost = 10., nu=.9), X', y)
 ysknu2 = predict(sknu2, X')
 @test ysknu2 == ynu2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ y = Array(whiteside[:Temp])
 
 m = svmtrain(X, y, svmtype = EpsilonSVR, cost = 10., gamma = 1.)
 yeps, d = svmpredict(m, X)
-@test sum(yeps - y) ≈ 7.455509045783046
+@test_approx_eq(sum(yeps - y), 7.455509045783046)
 skm = fit!(EpsilonSVR(cost = 10., gamma = 1.), X', y)
 ysk = predict(skm, X')
 @test yeps == ysk
@@ -35,14 +35,14 @@ ysk = predict(skm, X')
 nu1 = svmtrain(X, y, svmtype = NuSVR, cost = 10.,
                 nu = .7, gamma = 2., tolerance = .001)
 ynu1, d = svmpredict(nu1, X)
-@test sum(ynu1 - y) ≈ 14.184665717092
+@test_approx_eq(sum(ynu1 - y), 14.184665717092)
 sknu1 = fit!(NuSVR(cost = 10., nu=.7, gamma = 2.), X', y)
 ysknu1 = predict(sknu1, X')
 @test ysknu1 == ynu1
 
 nu2 = svmtrain(X, y, svmtype = NuSVR, cost = 10., nu = .9)
 ynu2, d =svmpredict(nu2, X)
-@test sum(ynu2 - y) ≈ 6.686819661799177
+@test_approx_eq(sum(ynu2 - y), 6.686819661799177)
 sknu2 = fit!(NuSVR(cost = 10., nu=.9), X', y)
 ysknu2 = predict(sknu2, X')
 @test ysknu2 == ynu2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,8 +10,8 @@ gc()
 correct = Bool[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1]
 @test (class .== labels[2:2:end]) == correct
 
-skmodel = fit!(SVC(), instances[:,1:2:end], labels[1:2:end])
-skclass = predict(skmodel, instances[:, 2:2:end])
+skmodel = fit!(SVC(), instances[:,1:2:end]', labels[1:2:end])
+skclass = predict(skmodel, instances[:, 2:2:end]')
 @test skclass == class
 
 model = svmtrain(sparse(instances[:, 1:2:end]), labels[1:2:end]; verbose=true)
@@ -28,21 +28,21 @@ y = Array(whiteside[:Temp])
 m = svmtrain(X, y, svmtype = EpsilonSVR, cost = 10., gamma = 1.)
 yeps, d = svmpredict(m, X)
 @test_approx_eq(sum(yeps - y), 7.455509045783046)
-skm = fit!(EpsilonSVR(cost = 10., gamma = 1.), X, y)
-ysk = predict(skm, X)
+skm = fit!(EpsilonSVR(cost = 10., gamma = 1.), X', y)
+ysk = predict(skm, X')
 @test yeps == ysk
 
 nu1 = svmtrain(X, y, svmtype = NuSVR, cost = 10.,
                 nu = .7, gamma = 2., tolerance = .001)
 ynu1, d = svmpredict(nu1, X)
 @test_approx_eq(sum(ynu1 - y), 14.184665717092)
-sknu1 = fit!(NuSVR(cost = 10., nu=.7, gamma = 2.), X, y)
-ysknu1 = predict(sknu1, X)
+sknu1 = fit!(NuSVR(cost = 10., nu=.7, gamma = 2.), X', y)
+ysknu1 = predict(sknu1, X')
 @test ysknu1 == ynu1
 
 nu2 = svmtrain(X, y, svmtype = NuSVR, cost = 10., nu = .9)
 ynu2, d =svmpredict(nu2, X)
 @test_approx_eq(sum(ynu2 - y), 6.686819661799177)
-sknu2 = fit!(NuSVR(cost = 10., nu=.9), X, y)
-ysknu2 = predict(sknu2, X)
+sknu2 = fit!(NuSVR(cost = 10., nu=.9), X', y)
+ysknu2 = predict(sknu2, X')
 @test ysknu2 == ynu2


### PR DESCRIPTION
LIBSVM.jl does not fully support [ScikitLearn.jl](https://github.com/cstjean/ScikitLearn.jl). So I cannot use some method (cross_val_score, GridSearchCV, etc...) in ScikitLearn.jl.
To solve the problem, I made the following changes.

I implemented it according to this [doc](https://github.com/cstjean/ScikitLearnBase.jl/blob/master/docs/API.md).

 ## Changes summary

* Implement [`declare_hyperparameters`](https://github.com/cstjean/ScikitLearnBase.jl/blob/master/docs/API.md#rolling-your-own-estimator).
* Change some methods X parameter shape (n_features, n_samples) -> (n_samples, n_features).