### PR TITLE
Multithreading via OpenMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,16 +66,6 @@ svrmod = fit!(EpsilonSVR(cost = 10., gamma = 1.), X, y)
 yp = predict(svrmod, X)
 ```
 
-#Multithreading via OpenMP
-
-You can enable multithreading by 'exporting' the *OMP_NUM_THREADS* variable before training and prediction.
-
-```julia
-@time model = svmtrain(instances[:, 1:2:end], labels[1:2:end]);
-ENV{"OMP_NUM_THREADS"} = 8
-@time model = svmtrain(instances[:, 1:2:end], labels[1:2:end]);
-```
-
 ## Credits
 
 The library is currently developed and maintained by Matti Pastell. It was originally

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ svrmod = fit!(EpsilonSVR(cost = 10., gamma = 1.), X, y)
 yp = predict(svrmod, X)
 ```
 
+#Multithreading via OpenMP
+
+You can enable multithreading by 'exporting' the *OMP_NUM_THREADS* variable before training and prediction.
+
+```julia
+@time model = svmtrain(instances[:, 1:2:end], labels[1:2:end]);
+ENV{"OMP_NUM_THREADS"} = 8
+@time model = svmtrain(instances[:, 1:2:end], labels[1:2:end]);
+```
+
 ## Credits
 
 The library is currently developed and maintained by Matti Pastell. It was originally

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,9 +3,9 @@ if is_windows()
     lib = joinpath(joinpath(dirname(@__FILE__), "libsvm.dll"))
     info("Downloading LIBSVM binary")
     if Sys.WORD_SIZE == 64
-        download("https://mpastell.github.io/LIBSVM.jl/bindeps/libsvm-3.22_0.dll", lib)
+        download("http://web.ics.purdue.edu/~finej/libsvm-3.22_1.dll", lib)
     else
-        download("https://mpastell.github.io/LIBSVM.jl/bindeps/libsvm32-3.22_0.dll", lib)
+        download("http://web.ics.purdue.edu/~finej/libsvm32-3.22_1.dll", lib)
     end
 else
     cd(joinpath(dirname(@__FILE__), "libsvm-3.22"))

--- a/deps/libsvm-3.22/Makefile
+++ b/deps/libsvm-3.22/Makefile
@@ -1,5 +1,5 @@
 CXX ?= g++
-CFLAGS = -Wall -Wconversion -O3 -fPIC
+CFLAGS = -Wall -Wconversion -O3 -fPIC -fopenmp
 SHVER = 2
 OS = $(shell uname)
 
@@ -11,7 +11,7 @@ lib: svm.o
 	else \
 		SHARED_LIB_FLAG="-shared -Wl,-soname,libsvm.so.$(SHVER)"; \
 	fi; \
-	$(CXX) $${SHARED_LIB_FLAG} svm.o -o libsvm.so.$(SHVER)
+	$(CXX) $${SHARED_LIB_FLAG} -fopenmp svm.o -o libsvm.so.$(SHVER)
 
 svm-predict: svm-predict.c svm.o
 	$(CXX) $(CFLAGS) svm-predict.c svm.o -o svm-predict -lm

--- a/deps/libsvm-3.22/Makefile.win32
+++ b/deps/libsvm-3.22/Makefile.win32
@@ -1,0 +1,10 @@
+CXX ?= cl.exe
+CFLAGS =  nologo /O2 /EHsc /I. /D _CRT_SECURE_NO_DEPRECATE /openmp
+
+all: lib
+
+lib: svm.cpp svm.h svm.def
+	$(CXX) $(CFLAGS) -LD svm.cpp -Felibsvm -link -DEF:svm.def
+
+clean:
+	rm -f *~ svm.obj libsvm.dll libsvm.lib libsvm.exp

--- a/deps/libsvm-3.22/Makefile.win64
+++ b/deps/libsvm-3.22/Makefile.win64
@@ -1,0 +1,10 @@
+CXX ?= cl.exe
+CFLAGS =  nologo /O2 /EHsc /I. /D _WIN64 /D _CRT_SECURE_NO_DEPRECATE /openmp
+
+all: lib
+
+lib: svm.cpp svm.h svm.def
+	$(CXX) $(CFLAGS) -LD svm.cpp -Felibsvm -link -DEF:svm.def
+
+clean:
+	rm -f *~ svm.obj libsvm.dll libsvm.lib libsvm.exp

--- a/deps/libsvm-3.22/svm.cpp
+++ b/deps/libsvm-3.22/svm.cpp
@@ -1282,6 +1282,7 @@ public:
 		int start, j;
 		if((start = cache->get_data(i,&data,len)) < len)
 		{
+			#pragma omp parallel for private(j) schedule(guided)
 			for(j=start;j<len;j++)
 				data[j] = (Qfloat)(y[i]*y[j]*(this->*kernel_function)(i,j));
 		}
@@ -1397,6 +1398,7 @@ public:
 		int j, real_i = index[i];
 		if(cache->get_data(real_i,&data,l) < l)
 		{
+			#pragma omp parallel for private(i) schedule(guided)
 			for(j=0;j<l;j++)
 				data[j] = (Qfloat)(this->*kernel_function)(real_i,j);
 		}
@@ -2507,6 +2509,7 @@ double svm_predict_values(const svm_model *model, const svm_node *x, double* dec
 	{
 		double *sv_coef = model->sv_coef[0];
 		double sum = 0;
+		#pragma omp parallel for private(i) reduction(+:sum) schedule(guided)
 		for(i=0;i<model->l;i++)
 			sum += sv_coef[i] * Kernel::k_function(x,model->SV[i],model->param);
 		sum -= model->rho[0];
@@ -2523,6 +2526,7 @@ double svm_predict_values(const svm_model *model, const svm_node *x, double* dec
 		int l = model->l;
 		
 		double *kvalue = Malloc(double,l);
+		#pragma omp parallel for private(i) schedule(guided)
 		for(i=0;i<l;i++)
 			kvalue[i] = Kernel::k_function(x,model->SV[i],model->param);
 

--- a/deps/libsvm-3.22/svm.cpp
+++ b/deps/libsvm-3.22/svm.cpp
@@ -8,6 +8,7 @@
 #include <limits.h>
 #include <locale.h>
 #include "svm.h"
+#include "omp.h"
 int libsvm_version = LIBSVM_VERSION;
 typedef float Qfloat;
 typedef signed char schar;
@@ -3182,4 +3183,14 @@ void svm_set_print_string_function(void (*print_func)(const char *))
 		svm_print_string = &print_string_stdout;
 	else
 		svm_print_string = print_func;
+}
+
+void svm_set_num_threads(int num_threads)
+{
+	omp_set_num_threads(num_threads);
+}
+
+int svm_get_max_threads()
+{
+	return omp_get_max_threads();
 }

--- a/deps/libsvm-3.22/svm.def
+++ b/deps/libsvm-3.22/svm.def
@@ -1,0 +1,23 @@
+LIBRARY libsvm
+EXPORTS
+	svm_train	@1
+	svm_cross_validation	@2
+	svm_save_model	@3
+	svm_load_model	@4
+	svm_get_svm_type	@5
+	svm_get_nr_class	@6
+	svm_get_labels	@7
+	svm_get_svr_probability	@8
+	svm_predict_values	@9
+	svm_predict	@10
+	svm_predict_probability	@11
+	svm_free_model_content	@12
+	svm_free_and_destroy_model	@13
+	svm_destroy_param	@14
+	svm_check_parameter	@15
+	svm_check_probability_model	@16
+	svm_set_print_string_function	@17
+	svm_get_sv_indices	@18
+	svm_get_nr_sv	@19
+    svm_set_num_threads @20
+    svm_get_max_threads @21

--- a/deps/libsvm-3.22/svm.h
+++ b/deps/libsvm-3.22/svm.h
@@ -97,6 +97,10 @@ int svm_check_probability_model(const struct svm_model *model);
 
 void svm_set_print_string_function(void (*print_func)(const char *));
 
+void svm_set_num_threads(int num_threads);
+
+int svm_get_max_threads();
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,3 +46,19 @@ ynu2, d =svmpredict(nu2, X)
 sknu2 = fit!(NuSVR(cost = 10., nu=.9), X', y)
 ysknu2 = predict(sknu2, X')
 @test isapprox(ysknu2,ynu2)
+
+# Multithreading testing
+
+# Assign by maximum number of threads
+ntnu1 = svmtrain(X, y, svmtype = NuSVR, cost = 10.,
+                nu = .7, gamma = 2., tolerance = .001,
+                nt = -1)
+ntynu1, ntd = svmpredict(ntnu1, X)
+@test sum(ntynu1 - y) ≈  14.184665717092
+
+# Assign by environment
+ENV["OMP_NUM_THREADS"] = 2
+
+ntm = svmtrain(X, y, svmtype = EpsilonSVR, cost = 10., gamma = 1.)
+ntyeps, ntd = svmpredict(m, X)
+@test sum(ntyeps - y) ≈ 7.455509045783046

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,7 @@ yeps, d = svmpredict(m, X)
 @test sum(yeps - y) ≈ 7.455509045783046
 skm = fit!(EpsilonSVR(cost = 10., gamma = 1.), X', y)
 ysk = predict(skm, X')
-@test yeps == ysk
+@test isapprox(yeps,ysk)
 
 nu1 = svmtrain(X, y, svmtype = NuSVR, cost = 10.,
                 nu = .7, gamma = 2., tolerance = .001)
@@ -38,11 +38,11 @@ ynu1, d = svmpredict(nu1, X)
 @test sum(ynu1 - y) ≈  14.184665717092
 sknu1 = fit!(NuSVR(cost = 10., nu=.7, gamma = 2.), X', y)
 ysknu1 = predict(sknu1, X')
-@test ysknu1 == ynu1
+@test isapprox(ysknu1,ynu1)
 
 nu2 = svmtrain(X, y, svmtype = NuSVR, cost = 10., nu = .9)
 ynu2, d =svmpredict(nu2, X)
 @test sum(ynu2 - y) ≈ 6.686819661799177
 sknu2 = fit!(NuSVR(cost = 10., nu=.9), X', y)
 ysknu2 = predict(sknu2, X')
-@test ysknu2 == ynu2
+@test isapprox(ysknu2,ynu2)


### PR DESCRIPTION
Adding OpenMP support to svm.cpp. Enabling it is a bit clunky, but standard for OpenMP support.

A potential issue is a compatible compiler for OpenMP is required to build the library. 

See:
[https://www.csie.ntu.edu.tw/~cjlin/libsvm/faq.html#f432](https://www.csie.ntu.edu.tw/~cjlin/libsvm/faq.html#f432)