### PR TITLE
If compilation fails with the `-fopenmp` flag, retry without the `-fopenmp` flag. Fixes #39

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.so.2
 *.o
 test*.jl
+
+deps/build.log

--- a/deps/libsvm-3.22/Makefile
+++ b/deps/libsvm-3.22/Makefile
@@ -1,25 +1,47 @@
 CXX ?= g++
-CFLAGS = -Wall -Wconversion -O3 -fPIC -fopenmp
+CFLAGS_normal = -Wall -Wconversion -O3 -fPIC -DENABLEOPENMP -fopenmp
+CFLAGS_fallback = -Wall -Wconversion -O3 -DDISABLEOPENMP -fPIC
 SHVER = 2
 OS = $(shell uname)
 
 all: svm-train svm-predict svm-scale
 
-lib: svm.o
+lib:
+	$(MAKE) lib_normal || $(MAKE) lib_fallback
+
+lib_normal: svm.o
 	if [ "$(OS)" = "Darwin" ]; then \
 		SHARED_LIB_FLAG="-dynamiclib -Wl,-install_name,libsvm.so.$(SHVER)"; \
 	else \
 		SHARED_LIB_FLAG="-shared -Wl,-soname,libsvm.so.$(SHVER)"; \
 	fi; \
-	$(CXX) $${SHARED_LIB_FLAG} -fopenmp svm.o -o libsvm.so.$(SHVER)
+	$(CXX) $${SHARED_LIB_FLAG} -DENABLEOPENMP -fopenmp svm.o -o libsvm.so.$(SHVER)
+
+lib_fallback: svm.o
+	if [ "$(OS)" = "Darwin" ]; then \
+		SHARED_LIB_FLAG="-dynamiclib -Wl,-install_name,libsvm.so.$(SHVER)"; \
+	else \
+		SHARED_LIB_FLAG="-shared -Wl,-soname,libsvm.so.$(SHVER)"; \
+	fi; \
+	$(CXX) $${SHARED_LIB_FLAG} -DDISABLEOPENMP svm.o -o libsvm.so.$(SHVER)
 
 svm-predict: svm-predict.c svm.o
 	$(CXX) $(CFLAGS) svm-predict.c svm.o -o svm-predict -lm
+
 svm-train: svm-train.c svm.o
 	$(CXX) $(CFLAGS) svm-train.c svm.o -o svm-train -lm
+
 svm-scale: svm-scale.c
 	$(CXX) $(CFLAGS) svm-scale.c -o svm-scale
-svm.o: svm.cpp svm.h
-	$(CXX) $(CFLAGS) -c svm.cpp
+
+svm.o:
+	$(MAKE) svm.o_normal || $(MAKE) svm.o_fallback
+
+svm.o_normal: svm.cpp svm.h
+	$(CXX) $(CFLAGS_normal) -c svm.cpp
+
+svm.o_fallback: svm.cpp svm.h
+	$(CXX) $(CFLAGS_fallblack) -c svm.cpp
+
 clean:
 	rm -f *~ svm.o svm-train svm-predict svm-scale libsvm.so.$(SHVER)

--- a/deps/libsvm-3.22/svm.cpp
+++ b/deps/libsvm-3.22/svm.cpp
@@ -8,7 +8,14 @@
 #include <limits.h>
 #include <locale.h>
 #include "svm.h"
-#include "omp.h"
+
+#ifdef ENABLEOPENMP
+    #include "omp.h"
+#else
+    #define omp_get_max_threads() 0
+    #define omp_set_num_threads(num_threads) void
+#endif
+
 int libsvm_version = LIBSVM_VERSION;
 typedef float Qfloat;
 typedef signed char schar;


### PR DESCRIPTION
This PR fixes #39. First, we try to compile with the `-fopenmp` flag. However, if compilation fails, then we retry without the `-fopenmp` flag.